### PR TITLE
Set video resolution to 1080p max instead of "original" max

### DIFF
--- a/src/components/VideoItem/index.tsx
+++ b/src/components/VideoItem/index.tsx
@@ -73,7 +73,7 @@ const VideoItem: React.FC<VideoItemProps> = (props) => {
   // the filter changes
   useEffect(() => {
     videoRef.current?.load();
-  }, [props.scene.path]);
+  }, [props.scene.path + "?resolution=FULL_HD"]);
 
   /* ------------------------------- Play/pause ------------------------------- */
 
@@ -308,7 +308,7 @@ const VideoItem: React.FC<VideoItemProps> = (props) => {
         playsInline
         ref={videoRef}
       >
-        <source src={props.scene.path} type={`video/${props.scene.format}`} />
+        <source src={props.scene.path + "?resolution=FULL_HD"} type={`video/${props.scene.format === "matroska" ? "mp4" : props.scene.format}`} />
         {captionSources}
       </video>
       <Transition


### PR DESCRIPTION
Also handles matroska files which need to be converted to mp4 by setting format to video/mp4 to stream properly.

This allows, for example, 4k AV1 matroska videos to convert to 1080p mp4 files for use in the reels viewer, without affecting lower quality videos. 4k+ streams tend to load too slowly anyway and use too much memory to cache in many of them.